### PR TITLE
ENH: Force db engine dispose on session close 

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -62,6 +62,7 @@ def get_session():
         yield session
     finally:
         session.close()
+        close_db()  # May fix issues with connections to database remaining open, but not force connection closure until session activity complete.
 
 
 def close_db(e=None):


### PR DESCRIPTION
Connection pool continues to grow in web worker as new engines are created for out of scope work.  This may be due to a regression in engine creation during redis asynchronous ingest implementation.  Since the IO of the application should be infrequent, forcing connection closure on web workers with a reasonable cache should still yield reasonable performance.