### PR TITLE
FIX: autorenumbering of ID added to product transformation stack

### DIFF
--- a/api/utils/ingest.py
+++ b/api/utils/ingest.py
@@ -154,6 +154,7 @@ def assign_product_transforms(**kwargs):
     """Assemble trial data transforms for clean write"""
     transform_list = [
         null_transform,
+        renumber_id,
         make_subset_ingest(model=Sponsor, columns=['Sponsor', 'Source?']),
         make_subset_ingest(model=ProductSponsor, columns=[
                            'ID', 'Sponsor', 'Source?']),

--- a/api/utils/transform/__init__.py
+++ b/api/utils/transform/__init__.py
@@ -17,3 +17,5 @@ from .milestones import milestone_transformer, get_milestone_renaming_schema
 from .endpoint import *
 
 from .common import *
+
+from .products import *

--- a/api/utils/transform/common/casting.py
+++ b/api/utils/transform/common/casting.py
@@ -13,7 +13,7 @@ def convert_to_datetime(time_string):
         return None
 
 
-def cast_to_int(series: pd.Series)->pd.Series:
+def cast_to_int(series: pd.Series, replace=True)->pd.Series:
     for i, item in enumerate(series):
         try:
             if item is not None and item is not np.nan:

--- a/api/utils/transform/common/dataframe_manipulation.py
+++ b/api/utils/transform/common/dataframe_manipulation.py
@@ -63,7 +63,7 @@ def clean_null(data: pd.DataFrame):
 
 def drop_unnamed_columns(df:pd.DataFrame)->pd.DataFrame:
     tlogg.info('drop_unnamed_columns')
-    keep_columns = [col for col in df.columns if len(col)>0]
+    keep_columns = [col for col in df.columns if len(str(col))>0]
     return df[keep_columns].copy()
 
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -27,17 +27,18 @@ class LocalDatabaseTest(LiveServerTestCase):
         return app
 
     def setUp(self):
-        self.test_frame = pd.read_csv('/home/vbrandon/Bin/py-api-vac-rnd-dash/data/vaccines/vaccineworkfile1.csv')
+        self.test_frame = pd.read_csv('/home/vbrandon/Bin/py-api-vac-rnd-dash/data/vaccines/vaccineworkfile3.csv')
 
     def test_get_product_names(self):
         self.assertIsNotNone(get_product_names())
 
     def test_explicit_loader(self):
         loader = "unfiltered_csv"
-        file_url = 'https://raw.githubusercontent.com/c19-rnd-dashboard/py-api-vac-rnd-dash/master/data/vaccines/vaccineworkfile2.csv'
+        file_url = 'https://raw.githubusercontent.com/c19-rnd-dashboard/py-api-vac-rnd-dash/master/data/vaccines/vaccineworkfile3.csv'
         output = load(
             file_or_buffer=file_url,
             loader=loader,
+            # max_len=371,
         )
         self.assertIsNotNone(output)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,7 +30,7 @@ class IngestTest(LiveServerTestCase):
     def test_explicit_ingest(self):
         category = 'product'
         loader = "unfiltered_csv"
-        error = run_ingest(source=self.test_product_url, category=category, loader=loader)
+        error = run_ingest(source=self.test_product_url, category=category, loader=loader, max_len=923)
         self.assertIsNone(error)
 
     def test_object_ingest_countries(self):


### PR DESCRIPTION
Also added kwarg option max_len to unfiltered_csv loader to manually specify tail limit.